### PR TITLE
Add weather API endpoint and Vercel config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ Sunset District in San Francisco.
    ```
 
 When deployed to Vercel, the `/weather` endpoint will return the current
-conditions in JSON format.
+conditions in JSON format. The root `index.html` page fetches this endpoint and
+displays the JSON response in the browser.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# sunshine
+# Sunshine Weather API
+
+Simple Express API deployed on Vercel that returns the current weather for the
+Sunset District in San Francisco.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the server locally:
+   ```bash
+   npm start
+   ```
+
+When deployed to Vercel, the `/weather` endpoint will return the current
+conditions in JSON format.

--- a/api/weather.js
+++ b/api/weather.js
@@ -27,3 +27,10 @@ app.get('/', async (req, res) => {
 });
 
 module.exports = app;
+
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`Server running on http://localhost:${PORT}`);
+  });
+}

--- a/api/weather.js
+++ b/api/weather.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const axios = require('axios');
+
+const app = express();
+
+app.get('/', async (req, res) => {
+  try {
+    const { data } = await axios.get('https://api.openweathermap.org/data/3.0/weather', {
+      params: {
+        lat: 37.75,
+        lon: -122.5,
+        units: 'metric',
+        appid: '92e1aa040a1cacb34144d17cd1d650f4'
+      }
+    });
+
+    res.json({
+      location: 'Sunset District, San Francisco',
+      temperature: data.main.temp,
+      weather: data.weather[0].main,
+      description: data.weather[0].description,
+      timestamp: new Date().toISOString()
+    });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch weather' });
+  }
+});
+
+module.exports = app;

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sunset Weather</title>
+  <style>
+    body { font-family: sans-serif; padding: 2rem; }
+    pre { background: #f4f4f4; padding: 1rem; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <h1>Current Weather</h1>
+  <pre id="output">Loading...</pre>
+  <script>
+    fetch('/weather')
+      .then(res => res.json())
+      .then(data => {
+        document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+      })
+      .catch(err => {
+        document.getElementById('output').textContent = 'Error fetching data';
+        console.error(err);
+      });
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "sunshine",
+  "version": "1.0.0",
+  "description": "",
+  "main": "api/weather.js",
+  "scripts": {
+    "start": "node api/weather.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "axios": "^1.6.0",
+    "express": "^4.18.2"
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "api/weather.js", "use": "@vercel/node" }
+  ],
+  "routes": [
+    { "src": "/weather", "dest": "api/weather.js" }
+  ]
+}


### PR DESCRIPTION
## Summary
- create Express serverless function `api/weather.js`
- define dependencies and start script in `package.json`
- configure Vercel deployment with `vercel.json`
- update `README` with setup instructions

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: 403 Forbidden due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68621a5ff7a4833383e43a6b52bd3a97