### PR TITLE
Switch to direct_radiation API

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,13 +25,13 @@
 </table>
 <script>
 async function fetchRadiation() {
-  const url = 'https://api.open-meteo.com/v1/forecast?latitude=37.7463&longitude=-122.5055&hourly=direct_radiation_instant&forecast_days=1';
+  const url = 'https://api.open-meteo.com/v1/forecast?latitude=37.7463&longitude=-122.5055&hourly=direct_radiation&forecast_days=1&timezone=auto';
   try {
     const response = await fetch(url);
     if (!response.ok) throw new Error('Network response was not ok');
     const data = await response.json();
     const times = data.hourly.time;
-    const radiation = data.hourly.direct_radiation_instant;
+    const radiation = data.hourly.direct_radiation;
     const tbody = document.querySelector('#radiation-table tbody');
     tbody.innerHTML = '';
     for (let i = 0; i < times.length; i++) {


### PR DESCRIPTION
## Summary
- request `direct_radiation` data instead of the instantaneous value
- look for `hourly.direct_radiation` in the API response
- include `timezone=auto` so timestamps are local

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68637b18b8cc833389137831d91a98b0